### PR TITLE
Move glslify transform from build scripts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
     "hammerjs": "git://github.com/digisfera/hammer.js.git",
     "minimal-event-emitter": "^0.1.0"
   },
+  "browserify": {
+    "transform": [
+      "glslify"
+    ]
+  },
   "devDependencies": {
     "async": "^1.5.2",
     "browserify": "^13.0.0",

--- a/scripts/build
+++ b/scripts/build
@@ -30,7 +30,6 @@ make-swf $DIST/marzipano.swf
 
 browserify \
   --noparse=node_modules/**/*.js \
-  -t glslify \
   -s Marzipano \
   -o $DIST/marzipano.js \
   $SRC/index.js

--- a/scripts/dev
+++ b/scripts/dev
@@ -28,7 +28,6 @@ make-swf $BUILD/marzipano.swf
 
 watchify -v -d \
   --noparse=node_modules/**/*.js \
-  -t glslify \
   -s Marzipano \
   -o $BUILD/marzipano.js \
   $SRC/index.js &


### PR DESCRIPTION
Move `glslify` transform from build scripts to `package.json` so the library can be required to other codebases without the need for external configuration.

Fixes use case for issue #21.