### PR TITLE
Rename Stage#updateSize() to setSize() and pass in an explicit size.

### DIFF
--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -151,7 +151,8 @@ function Viewer(domElement, opts) {
   this._controlContainer.appendChild(controlCapture);
   domElement.appendChild(this._controlContainer);
 
-  // Respond to size changes.
+  // Respond to window size changes.
+  this._size = {};
   this.updateSize();
   this._updateSizeListener = this.updateSize.bind(this);
   window.addEventListener('resize', this._updateSizeListener);
@@ -221,6 +222,7 @@ Viewer.prototype.destroy = function() {
 
   window.removeEventListener('resize', this._updateSizeListener);
   this._updateSizeListener = null;
+  this._size = null;
 
   if (this._scene) {
     this._scene.view().removeEventListener('change', this._viewChangeHandler);
@@ -265,9 +267,15 @@ Viewer.prototype.destroy = function() {
 
 /**
  * Update the stage size to fill the containing element.
+ *
+ * This method is automatically called when the browser window is resized.
+ * Most clients won't need to explicitly call it to keep the size up to date.
  */
 Viewer.prototype.updateSize = function() {
-  this._stage.updateSize();
+  var size = this._size;
+  size.width = this._domElement.clientWidth;
+  size.height = this._domElement.clientHeight;
+  this._stage.setSize(size);
 };
 
 

--- a/src/stages/Css.js
+++ b/src/stages/Css.js
@@ -21,7 +21,6 @@ var browser = require('bowser');
 var inherits = require('../util/inherits');
 var loadImageHtml = require('./loadImageHtml');
 var setAbsolute = require('../util/dom').setAbsolute;
-var setPixelSize = require('../util/dom').setPixelSize;
 var setFullSize = require('../util/dom').setFullSize;
 var setNullTransformOrigin = require('../util/dom').setNullTransformOrigin;
 
@@ -85,14 +84,7 @@ CssStage.supported = function() {
 };
 
 
-CssStage.prototype._updateSize = function() {
-  var element = this._domElement;
-  var width = this._width;
-  var height = this._height;
-
-  // Update DOM element size.
-  setPixelSize(element, width, height);
-};
+CssStage.prototype._setSize = function() {};
 
 
 CssStage.prototype.loadImage = loadImageHtml;

--- a/src/stages/Flash.js
+++ b/src/stages/Flash.js
@@ -21,7 +21,6 @@ var WorkQueue = require('../collections/WorkQueue');
 var inherits = require('../util/inherits');
 var defer = require('../util/defer');
 var setAbsolute = require('../util/dom').setAbsolute;
-var setPixelSize = require('../util/dom').setPixelSize;
 var setFullSize = require('../util/dom').setFullSize;
 var setBlocking = require('../util/dom').setBlocking;
 var loadImageFlash = require('./loadImageFlash');
@@ -158,14 +157,7 @@ FlashStage.supported = function() {
 };
 
 
-FlashStage.prototype._updateSize = function() {
-  var element = this._domElement;
-  var width = this._width;
-  var height = this._height;
-
-  // Update DOM element size.
-  setPixelSize(element, width, height);
-};
+FlashStage.prototype._setSize = function() {};
 
 
 FlashStage.prototype.loadImage = function(tile, rect, done) {

--- a/src/stages/Stage.js
+++ b/src/stages/Stage.js
@@ -150,17 +150,21 @@ Stage.prototype.size = function(obj) {
 
 
 /**
- * Update the size by querying the DOM. This will usually be called from a
- * window.onresize event handler.
+ * Set the stage dimensions.
  *
  * This contains the size update logic common to all stage types. Subclasses
- * define the _updateSize() method to perform their own logic, if required.
+ * define the _setSize() method to perform their own logic, if required.
+ *
+ * @param {Object} obj
+ * @param {number} obj.width
+ * @param {number} obj.height
+ *
  */
-Stage.prototype.updateSize = function() {
-  this._width = this._domElement.parentElement.clientWidth;
-  this._height = this._domElement.parentElement.clientHeight;
+Stage.prototype.setSize = function(size) {
+  this._width = size.width;
+  this._height = size.height;
 
-  this._updateSize(); // defined by subclasses
+  this._setSize(); // must be defined by subclasses.
 
   this.emit('resize');
   this.emitRenderInvalid();

--- a/src/stages/WebGl.js
+++ b/src/stages/WebGl.js
@@ -125,7 +125,7 @@ WebGlStage.prototype.destroy = function() {
 
   this.constructor.super_.prototype.destroy.call(this);
 
-  this._domElement.removeEventListener('webglcontextlost', this._handleContextLoss);
+  this.removeEventListener('webglcontextlost', this._handleContextLoss);
   this._domElement = null;
   this._rendererInstances = null;
   this._gl = null;
@@ -145,20 +145,13 @@ WebGlStage.prototype.webGlContext = function() {
 };
 
 
-WebGlStage.prototype._updateSize = function() {
-  var element = this._domElement;
-  var width = this._width;
-  var height = this._height;
+WebGlStage.prototype._setSize = function() {
+  // Update the size of the canvas coordinate space. The size is obtained by
+  // taking the stage dimensions, which are set in CSS pixels, and multiplying
+  // them by the device pixel ratio.
   var ratio = pixelRatio();
-
-  // Update canvas size, scaling by the device pixel ratio.
-  this._domElement.width = ratio * width;
-  this._domElement.height = ratio * height;
-
-  // Update DOM element size.
-  // This must be done asynchronously on iOS 8 for the canvas to be scaled
-  // correctly.
-  defer(setPixelSize.bind(null, element, width, height));
+  this._domElement.width = ratio * this._width;
+  this._domElement.height = ratio * this._height;
 };
 
 


### PR DESCRIPTION
Passing in an explicit size enables the off-page rendering use case,
where the dimensions of the stage's underlying element can't be obtained
from the DOM. For regular clients, Viewer#updateSize() takes care of
getting the dimensions from the DOM and passing them into the stage on
the window resize handler.

Also clean up the ancilliary size update logic for the Css and Flash
stages. An explicit pixel size was being set on the DOM element, but this
is not required since the constructor sets its dimensions relative to the
parent element.