### PR TITLE
Actually remove event listeners in KeyControlMethod.destroy()

### DIFF
--- a/src/controls/Key.js
+++ b/src/controls/Key.js
@@ -71,9 +71,9 @@ eventEmitter(KeyControlMethod);
   Destroy the instance
 */
 KeyControlMethod.prototype.destroy = function() {
-  this._element.addEventListener('keydown', this._keydownHandler);
-  this._element.addEventListener('keyup', this._keyupHandler);
-  window.addEventListener('blur', this._blurHandler);
+  this._element.removeEventListener('keydown', this._keydownHandler);
+  this._element.removeEventListener('keyup', this._keyupHandler);
+  window.removeEventListener('blur', this._blurHandler);
 };
 
 KeyControlMethod.prototype._handlePress = function(e) {


### PR DESCRIPTION
`KeyControlMethod.destroy()` calls `addEventListener()`, which is a peculiar course of action for a destructor, and is perhaps due to a copy-and-paste mishap.

This is (mostly) of no consequence, but does lead to errors being logged when a window loses focus after a Marzipano instance has been destroyed, as the window.onblur handler for each of that instance’s `KeyControlMethod`s remains in place.

This PR thus corrects three calls to `addEventListener()` in `KeyControlMethod.destroy()` to `removeEventListener()`.