### PR TITLE
Fix hotspots issues in Android by using e.preventDefault() only for iPhone

### DIFF
--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -45,6 +45,8 @@ var DragCursor = require('./controls/DragCursor');
 
 var HammerGestures = require('./controls/HammerGestures');
 
+var browser = require('bowser');
+
 var stageMap = {
   webgl: WebGlStage,
   css: CssStage,
@@ -136,9 +138,9 @@ function Viewer(domElement, opts) {
   setFullSize(this._controlContainer);
 
   // Prevent bounce scroll effect on iOS.
-  // Applied only for iPhone, as Android's events must have the default action to allow a proper hotspots' usage
+  // Applied only for iOS, as Android's events must have the default action to allow interaction with hotspots.
   var userAgent = navigator.userAgent || navigator.vendor || window.opera;
-  if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
+  if (browser.ios) {
     this._controlContainer.addEventListener('touchstart', function(event) {
       event.preventDefault();
     });

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -136,9 +136,14 @@ function Viewer(domElement, opts) {
   setFullSize(this._controlContainer);
 
   // Prevent bounce scroll effect on iOS.
-  this._controlContainer.addEventListener('touchstart', function(event) {
-    event.preventDefault();
-  });
+  // Applied only for iPhone, as Android's events must have the default action to allow a proper hotspots' usage
+  var userAgent = navigator.userAgent || navigator.vendor || window.opera;
+  if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
+    this._controlContainer.addEventListener('touchstart', function(event) {
+      event.preventDefault();
+    });
+  }
+
 
   // Old IE does not detect mouse events on elements without background
   // Add a child element to the controls with full width, a background color


### PR DESCRIPTION
Hotspots work perfectly fine on Desktop & iPhone (Safari / Chrome). However, hotspots won't be responsive in Android at all.

Fixes issue #62.