### PR TITLE
Fix responsive hotspots on Android

### DIFF
--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -45,6 +45,8 @@ var DragCursor = require('./controls/DragCursor');
 
 var HammerGestures = require('./controls/HammerGestures');
 
+var browser = require('bowser');
+
 var stageMap = {
   webgl: WebGlStage,
   css: CssStage,
@@ -136,9 +138,14 @@ function Viewer(domElement, opts) {
   setFullSize(this._controlContainer);
 
   // Prevent bounce scroll effect on iOS.
-  this._controlContainer.addEventListener('touchstart', function(event) {
-    event.preventDefault();
-  });
+  // Applied only for iOS, as Android's events must have the default action to allow interaction with hotspots.
+  var userAgent = navigator.userAgent || navigator.vendor || window.opera;
+  if (browser.ios) {
+    this._controlContainer.addEventListener('touchstart', function(event) {
+      event.preventDefault();
+    });
+  }
+
 
   // Old IE does not detect mouse events on elements without background
   // Add a child element to the controls with full width, a background color

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -139,7 +139,6 @@ function Viewer(domElement, opts) {
 
   // Prevent bounce scroll effect on iOS.
   // Applied only for iOS, as Android's events must have the default action to allow interaction with hotspots.
-  var userAgent = navigator.userAgent || navigator.vendor || window.opera;
   if (browser.ios) {
     this._controlContainer.addEventListener('touchstart', function(event) {
       event.preventDefault();


### PR DESCRIPTION
Hotspots work perfectly fine on Desktop & iOS (Safari / Chrome). However, hotspots aren't responsive in Android at all.

Fixes issue #62.