### PR TITLE
Updated switchScene() to keep the current yaw

### DIFF
--- a/demos/sample-tour/index.js
+++ b/demos/sample-tour/index.js
@@ -175,6 +175,11 @@
 
   function switchScene(scene) {
     stopAutorotate();
+    var currentSceneElement = document.querySelector('#sceneList .scene.current') || document.querySelector('#sceneList .scene:first-child');
+    var currentScene = findSceneById(currentSceneElement.getAttribute('data-id'));
+    var viewParameters = JSON.parse(JSON.stringify(scene.data.initialViewParameters)); // clone the original
+    viewParameters.yaw = (scene.data.initialViewParameters.yaw || 0) + (currentScene.view._params.yaw - (currentScene.data.initialViewParameters.yaw || 0));
+    scene.view.setParameters(viewParameters);
     scene.view.setParameters(scene.data.initialViewParameters);
     scene.scene.switchTo();
     startAutorotate();


### PR DESCRIPTION
When switching scenes with the switchScene(), the yaw is always been reset to the initialViewParameters value of that scene. This piece of code tries to take the current yaw offset (from the initialViewParameters' value) and update the new yaw value for the newly switched scene. The prerequisite for this to work naturally is for all the scenes to have the same orientation in space (they are all facing the same side of the world, whether it is North, East, South or West), when setting the initial view.