### PR TITLE
Revert glslify package back to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bowser": "^1.3.0",
     "gl-matrix": "git://github.com/toji/gl-matrix.git#7c8d5dd",
+    "glslify": "^6.1.0",
     "hammerjs": "git://github.com/digisfera/hammer.js.git",
     "minimal-event-emitter": "^0.1.0"
   },
@@ -35,7 +36,6 @@
     "browserify": "^13.0.0",
     "deep-equal": "^1.0.1",
     "flex-sdk": "^4.6.0-0",
-    "glslify": "^6.1.0",
     "jsdoc": "^3.4.0",
     "lr-http-server": "^0.1.1",
     "mocha": "^3.0.1",


### PR DESCRIPTION
As per the comment thread on the `cd98315dc3` commit for `v0.7.1` I have moved the `glslify` package back to the dependency list. It was agreed it's not used for the build and can be considered critical to the function of `marzipano` and thus is a true dependency vs. a devDependency.

**[Comment thread](https://github.com/google/marzipano/commit/cd98315dc3bf15213bcac477d1654af728f29769#commitcomment-27824718)**