### PR TITLE
Setting cors settings to `use-credentials`

### DIFF
--- a/src/stages/loadImageHtml.js
+++ b/src/stages/loadImageHtml.js
@@ -32,10 +32,10 @@ function loadImageHtml(url, rect, done) {
 
   var img = new Image();
 
-  // Allow cross-domain image loading.
+  // Allow cross-domain image loading with support for authentication via cookies.
   // This is required to be able to create WebGL textures from images residing
   // on a different domain than the HTML document's.
-  img.crossOrigin = 'anonymous';
+  img.crossOrigin = 'use-credentials';
 
   var x = rect && rect.x || 0;
   var y = rect && rect.y || 0;


### PR DESCRIPTION
Updating _corsSettings_ for image loading to 'use-credentials'. This is required if you're loading images from an authenticated backend.