### PR TITLE
Emit network error from ImageUrl

### DIFF
--- a/src/NetworkError.js
+++ b/src/NetworkError.js
@@ -18,8 +18,10 @@
 var inherits = require('./util/inherits');
 
 // Class used to distinguish network failures from other kinds of errors.
-function NetworkError() {
+// https://stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript
+function NetworkError(message) {
   this.constructor.super_.apply(this, arguments);
+  this.message = message;
 }
 
 inherits(NetworkError, Error);

--- a/src/sources/ImageUrl.js
+++ b/src/sources/ImageUrl.js
@@ -15,6 +15,7 @@
  */
 'use strict';
 
+var eventEmitter = require('minimal-event-emitter');
 var NetworkError = require('../NetworkError');
 var WorkPool = require('../collections/WorkPool');
 var chain = require('../util/chain');
@@ -86,6 +87,7 @@ ImageUrlSource.prototype.loadAsset = function(stage, tile, done) {
         if (err instanceof NetworkError) {
           // If a network error occurred, wait before retrying.
           retryMap[url] = clock();
+          self.emit('networkError', asset, err);
         }
         done(err, tile);
       } else {
@@ -200,5 +202,6 @@ function propertyRegExp(property) {
   return new RegExp(regExpStr, 'g');
 }
 
+eventEmitter(ImageUrlSource);
 
 module.exports = ImageUrlSource;


### PR DESCRIPTION
Add `minimal-event-emitter` functionality to `ImageUrl` to be able to emit `networkError` events.

While doing this, I also realized that `NetworkError` can't extend built-in methods of native classes like `Error` (I was getting an empty string as the message), so I had to explicitly add `message` to the constructor method. Let me know if you think there's a cleaner way of doing this.