### PR TITLE
Loading images using workers

### DIFF
--- a/src/loaders/HtmlImage.js
+++ b/src/loaders/HtmlImage.js
@@ -43,6 +43,8 @@ function HtmlImageLoader(stage) {
   }
   this._stage = stage;
 
+  const self = this;
+
   // This variable will have the response callbacks where the keys will be 
   // the image URL and the value will be a function
   this._imageFetchersCallbacks = {};
@@ -50,8 +52,8 @@ function HtmlImageLoader(stage) {
   this._isSimpleImageFetcherWorker = true;
 
   function imageFetcherWorkerOnMessage(event) {
-    this._imageFetchersCallbacks[event.data.imageURL](event);
-    delete this._imageFetchersCallbacks[event.data.imageURL];
+    self._imageFetchersCallbacks[event.data.imageURL](event);
+    delete self._imageFetchersCallbacks[event.data.imageURL];
   }
 
   // Check what method can use for loading the images
@@ -62,17 +64,17 @@ function HtmlImageLoader(stage) {
    typeof window.createImageBitmap === "function"
   ) {
     this._imageFetcherNoResizeWorker = 
-      new require("../workers/fetchImageUsingImageBitmap")();
+      new Worker("../workers/fetchImageUsingImageBitmap.js");
 
     this._imageFetcherResizeWorker = 
-      new require("../workers/fetchImageUsingOffscreenCanvas")();
+      new Worker("../workers/fetchImageUsingOffscreenCanvas.js");
 
     this._imageFetcherNoResizeWorker.onmessage = imageFetcherWorkerOnMessage;
     this._imageFetcherResizeWorker.onmessage = imageFetcherWorkerOnMessage;
 
     this._isSimpleImageFetcherWorker = false;
   } else {
-    this._imageFetcherWorker = new require("../workers/fetchImage")();
+    this._imageFetcherWorker = new Worker("../workers/fetchImage.js");
 
     this._imageFetcherWorker.onmessage = imageFetcherWorkerOnMessage;
   }

--- a/src/loaders/HtmlImage.js
+++ b/src/loaders/HtmlImage.js
@@ -45,11 +45,11 @@ function HtmlImageLoader(stage) {
 
   const self = this;
 
+  this._useWorkers = false;
+
   // This variable will have the response callbacks where the keys will be 
   // the image URL and the value will be a function
   this._imageFetchersCallbacks = {};
-
-  this._isSimpleImageFetcherWorker = true;
 
   function imageFetcherWorkerOnMessage(event) {
     self._imageFetchersCallbacks[event.data.imageURL](event);
@@ -72,11 +72,7 @@ function HtmlImageLoader(stage) {
     this._imageFetcherNoResizeWorker.onmessage = imageFetcherWorkerOnMessage;
     this._imageFetcherResizeWorker.onmessage = imageFetcherWorkerOnMessage;
 
-    this._isSimpleImageFetcherWorker = false;
-  } else {
-    this._imageFetcherWorker = new Worker("../workers/fetchImage.js");
-
-    this._imageFetcherWorker.onmessage = imageFetcherWorkerOnMessage;
+    this._useWorkers = true;
   }
 }
 
@@ -99,54 +95,56 @@ HtmlImageLoader.prototype.loadImage = function(url, rect, done) {
   var cancelFunction;
   var shouldCancel = false;
 
-  if (this._isSimpleImageFetcherWorker) {
-    var internalCancelFunction;
+  if (!this._useWorkers) {
+    var img = new Image();
 
-    this._imageFetchersCallbacks[url] = function(event) {
-      if (shouldCancel) return;
+    // Allow cross-domain image loading.
+    // This is required to be able to create WebGL textures from images fetched
+    // from a different domain. Note that setting the crossorigin attribute to
+    // 'anonymous' will trigger a CORS preflight for cross-domain requests, but no
+    // credentials (cookies or HTTP auth) will be sent; to do so, the attribute
+    // would have to be set to 'use-credentials' instead. Unfortunately, this is
+    // not a safe choice, as it causes requests to fail when the response contains
+    // an Access-Control-Allow-Origin header with a wildcard. See the section
+    // "Credentialed requests and wildcards" on:
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+    img.crossOrigin = 'anonymous';
 
-      var img = new Image();
+    img.onload = () => {
+      if (x === 0 && y === 0 && width === 1 && height === 1) {
+        done(null, new StaticAsset(img));
+      }
+      else {
+        x *= img.naturalWidth;
+        y *= img.naturalHeight;
+        width *= img.naturalWidth;
+        height *= img.naturalHeight;
 
-      const objectURL = URL.createObjectURL(event.data.blob);
+        var canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        var context = canvas.getContext('2d');
 
-      img.onload = () => {
-          URL.revokeObjectURL(objectURL);
+        context.drawImage(img, x, y, width, height, 0, 0, width, height);
 
-          if (x === 0 && y === 0 && width === 1 && height === 1) {
-            done(null, new StaticAsset(img));
-          }
-          else {
-            x *= img.naturalWidth;
-            y *= img.naturalHeight;
-            width *= img.naturalWidth;
-            height *= img.naturalHeight;
-      
-            var canvas = document.createElement('canvas');
-            canvas.width = width;
-            canvas.height = height;
-            var context = canvas.getContext('2d');
-      
-            context.drawImage(img, x, y, width, height, 0, 0, width, height);
-      
-            done(null, new StaticAsset(canvas));
-          }
-      };
-
-      img.url = objectURL;
-
-      internalCancelFunction = function() {
-        img.onload = img.onerror = null;
-        img.src = '';
+        done(null, new StaticAsset(canvas));
       }
     };
 
+    img.onerror = function() {
+      // TODO: is there any way to distinguish a network error from other
+      // kinds of errors? For now we always return NetworkError since this
+      // prevents images to be retried continuously while we are offline.
+      done(new NetworkError('Network error: ' + url));
+    };
+
+    img.src = url;
+
     cancelFunction = function() {
-      shouldCancel = true;
-      if (internalCancelFunction) internalCancelFunction();
+      img.onload = img.onerror = null;
+      img.src = '';
       done.apply(null, arguments);
     }
-
-    this._imageFetcherWorker.postMessage({ imageURL: url });
   } else {
     this._imageFetchersCallbacks[url] = function(event) {
       if (shouldCancel) return;

--- a/src/workers/fetchImage.js
+++ b/src/workers/fetchImage.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @class FetchImage
+ * @classdesc
+ * 
+ * Worker that load an image using fetch and return the blob of it
+ */
+
+/**
+ * @typedef {Object} WorkerResult
+ * @property {String} imageURL the URL of the image for identification
+ * @property {Blob} imageBlob the image data as a blob
+ */
+
+/**
+ * The listener of the worker
+ * 
+ * @param {String} imageURL the URL of the image
+ * 
+ * @returns {WorkerResult}
+ */
+onmessage = async event => {
+    postMessage({ 
+        imageURL: event.data.imageURL, 
+        imageBlob: await (await fetch(event.data.imageURL)).blob()
+    });
+};

--- a/src/workers/fetchImageUsingImageBitmap.js
+++ b/src/workers/fetchImageUsingImageBitmap.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @class FetchImageUsingImageBitmap
+ * @classdesc
+ * 
+ * Worker that load an image using fetch and createImageBitmap the return it
+ */
+
+/**
+ * @typedef {Object} WorkerResult
+ * @property {String} imageURL the URL of the image for identification
+ * @property {ImageBitmap} imageBitmap the image as an image bitmap
+ */
+
+/**
+ * The listener of the worker
+ * 
+ * @param {String} imageURL the URL of the image
+ * 
+ * @returns {WorkerResult}
+ */
+onmessage = async event => {
+    const blob = await (await fetch(event.data.imageURL)).blob();
+
+    postMessage({ 
+        imageURL: event.data.imageURL, 
+        imageBitmap: await createImageBitmap(
+            blob, 
+            { imageOrientation: "flipY" }
+        )
+    });
+};

--- a/src/workers/fetchImageUsingOffscreenCanvas.js
+++ b/src/workers/fetchImageUsingOffscreenCanvas.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @class FetchImageUsingOffscreenCanvasWorker
+ * @classdesc
+ * 
+ * Worker that load an image using fetch and createImageBitmap then resize it 
+ * using an offscreenCanvas and return an imageBitmap of the image
+ */
+
+/**
+ * @typedef {Object} WorkerResult
+ * @property {String} imageURL the URL of the image for identification
+ * @property {ImageBitmap} imageBitmap the image as an image bitmap
+ */
+
+/**
+ * The listener of the worker
+ * 
+ * @param {String} imageURL the URL of the image
+ * @param {OffscreenCanvas} canvas the canvas to draw the loaded image
+ * @param {Number} x The x coordinate
+ * @param {Number} y The y coordinate
+ * @param {Number} width The width
+ * @param {Number} height The width
+ * 
+ * @returns {WorkerResult}
+ */
+onmessage = async event => {
+    const blob = await (await fetch(event.data.imageURL)).blob();
+    let imageBitmap = await createImageBitmap(
+        blob, 
+        { imageOrientation: "flipY" }
+    );
+
+    const x = event.data.x;
+    const y = event.data.y;
+    const width = event.data.width;
+    const height = event.data.height;
+
+    const canvas = event.data.canvas;
+    const ctx = canvas.getContext("2d");
+    ctx.drawImage(b, x, y, width, height, 0, 0, width, height);
+    imageBitmap = await createImageBitmap(await canvas.convertToBlob());
+
+    postMessage({ 
+        imageURL: event.data.imageURL, 
+        imageBitmap: imageBitmap
+    });
+};


### PR DESCRIPTION
Now that workers are available pretty everywhere I think it would benefit `marzipano` to use them. I created this fork and it works on Chrome and only on Chrome will work until other browsers will implement `OffscreenCanvas` and `createImageBitmap`, but the workers files must be moved to the public_html/static folder of the website for the `Worker` constructor to be able to load them.

I created 3 workers:
- a worker that load the image using `createImageBitmap` and return the image bitmap; this worker is used when there is no need of transformations on the image;
- a worker that load the image using `createImageBitmap` and then transform it using `OffscreenCanvas`.

These workers are created in the constructor of `loaders/HtmlImage.js` where I check which workers are available on the current browser. If the features required for workers are not available we use the current implemented method using `<img>`

I know that there should be some refactoring done and I want to know what I need to refactor.
Also I don't what is the best method to handle the workers files that must be in the public_html/static folder.

I also create a worker for just fetching the the image data and returning a `Blob` and then load it normally using `<img>` but I don't see performance gains from doing this.