### PR TITLE
Fixed > Remove 'wheel' event listener on destroy in ScrollZoom control

### DIFF
--- a/src/controls/ScrollZoom.js
+++ b/src/controls/ScrollZoom.js
@@ -55,7 +55,7 @@ eventEmitter(ScrollZoomControlMethod);
  * Destructor.
  */
 ScrollZoomControlMethod.prototype.destroy = function() {
-  this._element.removeEventListener(this._wheelListener);
+  this._element.removeEventListener('wheel', this._wheelListener);
   clearOwnProperties(this);
 };
 


### PR DESCRIPTION
The destroy method on ScrollZoomCOntrolMethod contained a bad removeEventListener call