### PR TITLE
Feature: Add param for pinch drag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ package-lock.json
 /dist/*
 /docs/*
 /test/test_suite.js*
+.idea

--- a/src/controls/Drag.js
+++ b/src/controls/Drag.js
@@ -24,7 +24,8 @@ var clearOwnProperties = require('../util/clearOwnProperties');
 
 var defaultOptions = {
   friction: 6,
-  maxFrictionTime: 0.3
+  maxFrictionTime: 0.3,
+  hammerEvent: 'pan'
 };
 
 var debug = typeof MARZIPANODEBUG !== 'undefined' && MARZIPANODEBUG.controls;
@@ -42,6 +43,7 @@ var debug = typeof MARZIPANODEBUG !== 'undefined' && MARZIPANODEBUG.controls;
  * @param {Object} opts
  * @param {number} opts.friction
  * @param {number} opts.maxFrictionTime
+ * @param {'pan'|'pinch'} opts.hammerEvent
  */
 function DragControlMethod(element, pointerType, opts) {
   this._element = element;
@@ -62,11 +64,15 @@ function DragControlMethod(element, pointerType, opts) {
 
   this._hammer.on("hammer.input", this._handleHammerEvent.bind(this));
 
-  this._hammer.on('panstart', this._handleStart.bind(this));
-  this._hammer.on('panmove', this._handleMove.bind(this));
-  this._hammer.on('panend', this._handleEnd.bind(this));
-  this._hammer.on('pancancel', this._handleEnd.bind(this));
+  console.log(!['pan', 'pinch'].includes(this._opts.hammerEvent), this._opts.hammerEvent);
+  if (!['pan', 'pinch'].includes(this._opts.hammerEvent)) {
+    throw new Error(this._opts.hammerEvent + ' is not a hammerEvent managed in DragControlMethod');
+  }
 
+  this._hammer.on(this._opts.hammerEvent + 'start', this._handleStart.bind(this));
+  this._hammer.on(this._opts.hammerEvent + 'move', this._handleMove.bind(this));
+  this._hammer.on(this._opts.hammerEvent + 'end', this._handleEnd.bind(this));
+  this._hammer.on(this._opts.hammerEvent + 'cancel', this._handleEnd.bind(this));
 }
 
 eventEmitter(DragControlMethod);

--- a/src/controls/Drag.js
+++ b/src/controls/Drag.js
@@ -64,7 +64,7 @@ function DragControlMethod(element, pointerType, opts) {
 
   this._hammer.on("hammer.input", this._handleHammerEvent.bind(this));
 
-  if (!['pan', 'pinch'].includes(this._opts.hammerEvent)) {
+  if (this._opts.hammerEvent != 'pan' && this._opts.hammerEvent != 'pinch') {
     throw new Error(this._opts.hammerEvent + ' is not a hammerEvent managed in DragControlMethod');
   }
 

--- a/src/controls/Drag.js
+++ b/src/controls/Drag.js
@@ -64,7 +64,6 @@ function DragControlMethod(element, pointerType, opts) {
 
   this._hammer.on("hammer.input", this._handleHammerEvent.bind(this));
 
-  console.log(!['pan', 'pinch'].includes(this._opts.hammerEvent), this._opts.hammerEvent);
   if (!['pan', 'pinch'].includes(this._opts.hammerEvent)) {
     throw new Error(this._opts.hammerEvent + ' is not a hammerEvent managed in DragControlMethod');
   }

--- a/src/controls/HammerGestures.js
+++ b/src/controls/HammerGestures.js
@@ -52,7 +52,7 @@ HammerGestures.prototype.get = function(element, type) {
 
 
 HammerGestures.prototype._createManager = function(element, type) {
-  var manager = new Hammer.Manager(element, { dragMaxTouches: 2 });
+  var manager = new Hammer.Manager(element);
 
   // Managers are created with different parameters for different pointer
   // types.

--- a/src/controls/HammerGestures.js
+++ b/src/controls/HammerGestures.js
@@ -52,7 +52,7 @@ HammerGestures.prototype.get = function(element, type) {
 
 
 HammerGestures.prototype._createManager = function(element, type) {
-  var manager = new Hammer.Manager(element);
+  var manager = new Hammer.Manager(element, { dragMaxTouches: 2 });
 
   // Managers are created with different parameters for different pointer
   // types.

--- a/src/controls/registerDefaultControls.js
+++ b/src/controls/registerDefaultControls.js
@@ -41,17 +41,17 @@ var defaultOptions = {
  *
  * @param {Controls} controls Where to register the instances.
  * @param {Element} element Element to listen for events.
- * @param {Object} opts
- * @param {'drag'|'qtvr'} mouseViewMode
+ * @param {'drag'|'qtvr'} opts.mouseViewMode
+ * @param {boolean} opts.scrollZoom
+ * @param {'pinch'|'pan'} opts.dragMode
  */
 function registerDefaultControls(controls, element, opts) {
   opts = defaults(opts || {}, defaultOptions);
 
+
   var controlMethods = {
     mouseViewDrag: new DragControlMethod(element, 'mouse'),
     mouseViewQtvr: new QtvrControlMethod(element, 'mouse'),
-    touchView: new DragControlMethod(element, 'touch'),
-    pinch: new PinchZoomControlMethod(element, 'touch'),
 
     leftArrowKey: new KeyControlMethod(37, 'x', -0.7, 3),
     rightArrowKey: new KeyControlMethod(39, 'x', 0.7, 3),
@@ -68,6 +68,8 @@ function registerDefaultControls(controls, element, opts) {
     eKey: new KeyControlMethod(69, 'roll', -0.7, 3)
   };
 
+  var enabledControls = ['scrollZoom', 'touchView', 'pinch' ];
+
   if(opts.scrollZoom !== false) {
     controlMethods.scrollZoom = new ScrollZoomControlMethod(element); //{ frictionTime: 0 }
   }
@@ -80,7 +82,17 @@ function registerDefaultControls(controls, element, opts) {
   };
 
 
-  var enabledControls = [ 'scrollZoom', 'touchView', 'pinch' ];
+  switch (opts.dragMode) {
+    case 'pinch':
+       controlMethods.pinch = new DragControlMethod(element, 'touch', { hammerEvent: 'pinch'});
+      break;
+    default:
+    case 'pan':
+      controlMethods.touchView = new DragControlMethod(element, 'touch');
+      controlMethods.pinch = new PinchZoomControlMethod(element, 'touch');
+      break;
+  }
+
   switch (opts.mouseViewMode) {
     case 'drag':
       enabledControls.push('mouseViewDrag');

--- a/src/controls/registerDefaultControls.js
+++ b/src/controls/registerDefaultControls.js
@@ -84,13 +84,14 @@ function registerDefaultControls(controls, element, opts) {
 
   switch (opts.dragMode) {
     case 'pinch':
-       controlMethods.pinch = new DragControlMethod(element, 'touch', { hammerEvent: 'pinch'});
+       controlMethods.pinch = new DragControlMethod(element, 'touch', { hammerEvent: 'pinch' });
       break;
-    default:
     case 'pan':
       controlMethods.touchView = new DragControlMethod(element, 'touch');
       controlMethods.pinch = new PinchZoomControlMethod(element, 'touch');
       break;
+    default:
+      throw new Error("Unknown drag mode: " + opts.dragMode);
   }
 
   switch (opts.mouseViewMode) {


### PR DESCRIPTION
Hello there, 

We want to integrate a marzipano view in a scrollable page the current state of the library does not behave well in this case, when you have the marzipano view fullscreen in mobile you can't scroll anymore because it moves inside marzipano view instead of scrolling the page. So we would like to allow our user to move marzipano view with 2 fingers. 
I made a naïve implementation but it seems to work fine with the following configuration:
```js
  // Viewer options.
    var viewerOpts = {
      controls: {
        mouseViewMode: data.settings.mouseViewMode,
        dragMode: 'pinch'
      }
    };

    // Initialize viewer.
    var viewer = new Marzipano.Viewer(panoElement, viewerOpts);
```

Thank you !

related to https://github.com/google/marzipano/issues/367

(if it gets merge I will update my PR with typescript definition https://github.com/google/marzipano/pull/371)