### PR TITLE
Enabling pinch with any number of fingers

### DIFF
--- a/src/controls/Drag.js
+++ b/src/controls/Drag.js
@@ -60,11 +60,11 @@ function DragControlMethod(element, pointerType, opts) {
     y: new Dynamics()
   };
 
-  this._hammer = HammerGestures.get(element, pointerType);
+  this._hammer = HammerGestures.get(element, pointerType, this._opts.hammerEvent);
 
   this._hammer.on("hammer.input", this._handleHammerEvent.bind(this));
 
-  if (this._opts.hammerEvent != 'pan' && this._opts.hammerEvent != 'pinch') {
+  if (this._opts.hammerEvent != 'pan' && this._opts.hammerEvent != 'pinch' && this._opts.hammerEvent != 'multipinch') {
     throw new Error(this._opts.hammerEvent + ' is not a hammerEvent managed in DragControlMethod');
   }
 

--- a/src/controls/HammerGestures.js
+++ b/src/controls/HammerGestures.js
@@ -40,10 +40,10 @@ function HammerGestures() {
 }
 
 
-HammerGestures.prototype.get = function(element, type) {
+HammerGestures.prototype.get = function(element, type, hammerEvent) {
   var key = getKeyForElementAndType(element, type);
   if (!this._managers[key]) {
-    this._managers[key] = this._createManager(element, type);
+    this._managers[key] = this._createManager(element, type, hammerEvent);
     this._refCount[key] = 0;
   }
   this._refCount[key]++;
@@ -51,7 +51,7 @@ HammerGestures.prototype.get = function(element, type) {
 };
 
 
-HammerGestures.prototype._createManager = function(element, type) {
+HammerGestures.prototype._createManager = function(element, type, hammerEvent) {
   var manager = new Hammer.Manager(element);
 
   // Managers are created with different parameters for different pointer
@@ -63,7 +63,11 @@ HammerGestures.prototype._createManager = function(element, type) {
     // On touch one wants to have both panning and pinching. The panning
     // recognizer needs a threshold to allow the pinch to be recognized.
     manager.add(new Hammer.Pan({ direction: Hammer.DIRECTION_ALL, threshold: 20, pointers: 1 }));
-    manager.add(new Hammer.Pinch());
+    if (hammerEvent ==  'multipinch') {
+      manager.add(new Hammer.Pinch({event: 'multipinch', pointers: 0, threshold: 0}));      
+    } else {      
+      manager.add(new Hammer.Pinch());
+    }
   }
 
   return manager;

--- a/src/controls/registerDefaultControls.js
+++ b/src/controls/registerDefaultControls.js
@@ -68,7 +68,7 @@ function registerDefaultControls(controls, element, opts) {
     eKey: new KeyControlMethod(69, 'roll', -0.7, 3)
   };
 
-  var enabledControls = ['scrollZoom', 'touchView', 'pinch' ];
+  var enabledControls = ['scrollZoom', 'touchView', 'pinch', 'rotate' ];
 
   if (opts.scrollZoom !== false) {
     controlMethods.scrollZoom = new ScrollZoomControlMethod(element); //{ frictionTime: 0 }
@@ -83,8 +83,12 @@ function registerDefaultControls(controls, element, opts) {
 
 
   switch (opts.dragMode) {
+    case 'multipinch':
+      controlMethods.pinch = new DragControlMethod(element, 'touch', { hammerEvent: 'multipinch' });
+      controlMethods.touchView = new DragControlMethod(element, 'touch');
+      break;
     case 'pinch':
-       controlMethods.pinch = new DragControlMethod(element, 'touch', { hammerEvent: 'pinch' });
+      controlMethods.pinch = new DragControlMethod(element, 'touch', { hammerEvent: 'pinch' });
       break;
     case 'pan':
       controlMethods.touchView = new DragControlMethod(element, 'touch');


### PR DESCRIPTION
Hello,
By default, marzipano doesn't allow for multi finger dragging/rotating as seen here:
https://github.com/google/marzipano/issues/367
In my use case. I need to allow the user to drag/rotate the picture when using one, two or more fingers. I.e. no matter how many fingers the user is able to do the same thing.
As of version **_"marzipano": "0.10.2"_**, one can use two fingers when passing some "pinch" option! However, this has two limitations when it comes to my use case. First, it won't work when using more than two fingers. Second, if using a single finger it has no effect on the image and the scrolling happens (or is supposed to happen) on the containing page/widget.
This is a PR for allowing such thing. 